### PR TITLE
mitigate deprecation warning

### DIFF
--- a/src/uuid.erl
+++ b/src/uuid.erl
@@ -5,7 +5,7 @@
     ]).
 
 generate() ->
-    <<A:32, B:16, C:16, D:16, E:48>> = crypto:rand_bytes(16),
+    <<A:32, B:16, C:16, D:16, E:48>> = crypto:strong_rand_bytes(16),
     Str = io_lib:format("~8.16.0b-~4.16.0b-4~3.16.0b-~4.16.0b-~12.16.0b", 
                         [A, B, C band 16#0fff, D band 16#3fff bor 16#8000, E]),
     list_to_binary(Str).


### PR DESCRIPTION
Compiling gives this error:

Warning: crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1

This patch makes it go away.